### PR TITLE
Perf improvements

### DIFF
--- a/core-scroll-threshold.html
+++ b/core-scroll-threshold.html
@@ -30,7 +30,7 @@ triggered property.
 
 Example:
 
-    <core-scroll-threshold id="threshold" lowerThreshold="500" 
+    <core-scroll-threshold id="threshold" lowerThreshold="500"
       on-lower-trigger="{{loadMore}}" lowerTriggered="{{spinnerShouldShow}}">
     </core-scroll-threshold>
 
@@ -41,10 +41,21 @@ Example:
         this.$.threshold.clearLower();
       }.bind(this));
     }
-    
+
 @group Polymer Core Elements
 @element core-scroll-threshold
 @homepage github.io
+-->
+
+<!--
+Fired when `upperTriggered` becomes `true`.
+
+@event upper-trigger
+-->
+<!--
+Fired when `lowerTriggered` becomes `true`.
+
+@event lower-trigger
 -->
 
 <link rel="import" href="../polymer/polymer.html">
@@ -54,7 +65,7 @@ Example:
 <script>
 
   Polymer({
-    
+
     publish: {
 
       /**
@@ -153,7 +164,7 @@ Example:
       }
       if (!this.lowerThreshold) {
         this.lowerTriggered = false;
-      }      
+      }
     },
 
     checkThreshold: function(e) {

--- a/core-scroll-threshold.html
+++ b/core-scroll-threshold.html
@@ -139,7 +139,7 @@ Fired when `lowerTriggered` becomes `true`.
     detached: function() {
       // Remove listener for any previous scroll target
       if (this._scrollTarget) {
-        this._scrollTarget.removeEventListener(this._boundScrollHandler);
+        this._scrollTarget.removeEventListener('scroll', this._boundScrollHandler);
       }
     },
 
@@ -148,7 +148,7 @@ Fired when `lowerTriggered` becomes `true`.
 
       // Remove listener for any previous scroll target
       if (this._scrollTarget && (this._scrollTarget != target)) {
-        this._scrollTarget.removeEventListener(this._boundScrollHandler);
+        this._scrollTarget.removeEventListener('scroll', this._boundScrollHandler);
       }
 
       // Add listener for new scroll target
@@ -182,8 +182,7 @@ Fired when `lowerTriggered` becomes `true`.
 
           // No longer fire scroll events if there's no lower threshold or it
           // has been triggered.
-          if (this.lowerThreshold === null ||
-              (this.lowerThreshold !== null && this.lowerTriggered)) {
+          if (this.lowerThreshold === null || this.lowerTriggered) {
             this._scrollTarget.removeEventListener('scroll', this._boundScrollHandler);
           }
 
@@ -198,8 +197,7 @@ Fired when `lowerTriggered` becomes `true`.
 
           // No longer fire scroll events if there's no upper threshold or it
           // has been triggered.
-          if (this.upperThreshold === null ||
-              (this.upperThreshold !== null && this.upperTriggered)) {
+          if (this.upperThreshold === null || this.upperTriggered) {
             this._scrollTarget.removeEventListener('scroll', this._boundScrollHandler);
           }
 

--- a/core-scroll-threshold.html
+++ b/core-scroll-threshold.html
@@ -136,14 +136,22 @@ Fired when `lowerTriggered` becomes `true`.
       this._boundScrollHandler = this.checkThreshold.bind(this);
     },
 
-    setup: function() {
+    detached: function() {
       // Remove listener for any previous scroll target
-      if (this._scrollTarget && (this._scrollTarget != this.target)) {
+      if (this._scrollTarget) {
+        this._scrollTarget.removeEventListener(this._boundScrollHandler);
+      }
+    },
+
+    setup: function() {
+      var target = this.scrollTarget || this;
+
+      // Remove listener for any previous scroll target
+      if (this._scrollTarget && (this._scrollTarget != target)) {
         this._scrollTarget.removeEventListener(this._boundScrollHandler);
       }
 
       // Add listener for new scroll target
-      var target = this.scrollTarget || this;
       if (target) {
         this._scrollTarget = target;
         this._scrollTarget.addEventListener('scroll', this._boundScrollHandler);
@@ -169,16 +177,32 @@ Fired when `lowerTriggered` becomes `true`.
 
     checkThreshold: function(e) {
       var top = this._scrollTarget[this.scrollPosition];
-      if (!this.upperTriggered && this.upperThreshold != null) {
+      if (!this.upperTriggered && this.upperThreshold !== null) {
         if (top < this.upperThreshold) {
+
+          // No longer fire scroll events if there's no lower threshold or it
+          // has been triggered.
+          if (this.lowerThreshold === null ||
+              (this.lowerThreshold !== null && this.lowerTriggered)) {
+            this._scrollTarget.removeEventListener('scroll', this._boundScrollHandler);
+          }
+
           this.upperTriggered = true;
           this.fire('upper-trigger');
         }
       }
-      if (this.lowerThreshold != null) {
+      if (!this.lowerTriggered && this.lowerThreshold !== null) {
         var bottom = top + this._scrollTarget[this.sizeExtent];
         var size = this._scrollTarget[this.scrollExtent];
-        if (!this.lowerTriggered && (size - bottom) < this.lowerThreshold) {
+        if ((size - bottom) < this.lowerThreshold) {
+
+          // No longer fire scroll events if there's no upper threshold or it
+          // has been triggered.
+          if (this.upperThreshold === null ||
+              (this.upperThreshold !== null && this.upperTriggered)) {
+            this._scrollTarget.removeEventListener('scroll', this._boundScrollHandler);
+          }
+
           this.lowerTriggered = true;
           this.fire('lower-trigger');
         }
@@ -196,9 +220,10 @@ Fired when `lowerTriggered` becomes `true`.
           this.clearUpper();
         }.bind(this));
       } else {
-        requestAnimationFrame(function() {
+        this.async(function() {
           this.upperTriggered = false;
-        }.bind(this));
+          this._scrollTarget.addEventListener('scroll', this._boundScrollHandler);
+        });
       }
     },
 
@@ -213,9 +238,10 @@ Fired when `lowerTriggered` becomes `true`.
           this.clearLower();
         }.bind(this));
       } else {
-        requestAnimationFrame(function() {
+        this.async(function() {
           this.lowerTriggered = false;
-        }.bind(this));
+          this._scrollTarget.addEventListener('scroll', this._boundScrollHandler);
+        });
       }
     },
 
@@ -224,7 +250,7 @@ Fired when `lowerTriggered` becomes `true`.
         listener.call(this, observer, mutations);
         observer.disconnect();
       }.bind(this));
-      observer.observe(this._scrollTarget, {attributes:true, childList: true, subtree: true});
+      observer.observe(this._scrollTarget, {attributes: true, childList: true, subtree: true});
     }
 
   });

--- a/demo.html
+++ b/demo.html
@@ -43,7 +43,7 @@
       <div class="thing">{{i}}</div>
     </template>
     <div hidden?="{{!$.threshold.lowerTriggered}}">Please wait...</div>
-  </div> 
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
R: @kevinpschaaf, @brendankenny

- Fixes #7
- Fixes #8 - removes the `scroll` listener on `detached` and stops events if the threshold(s) have already been met.
- Fixes the undefined check (e.g. `this._scrollTarget != this.target`) in `setup()`

This also prevents extra checks to `offsetHeight` in `checkThreshold()` (e.g. `var bottom = top + this._scrollTarget[this.sizeExtent];`)